### PR TITLE
Remove obsolete settings in SublimeLinter >=4.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SublimeLinter-contrib-ansible-lint
 This linter plugin for [SublimeLinter][docs] provides an interface to [ansible-lint](https://github.com/willthames/ansible-lint). It will be used with files that have the “Ansible” syntax.
 
 ## Installation
-SublimeLinter 3 must be installed in order to use this plugin. If SublimeLinter 3 is not installed, please follow the instructions [here][installation].
+SublimeLinter 4 must be installed in order to use this plugin. If SublimeLinter 4 is not installed, please follow the instructions [here][installation].
 
 ### Linter installation
 Before using this plugin, you must ensure that `ansible-lint` is installed on your system. To install `ansible-lint`, do the following:

--- a/linter.py
+++ b/linter.py
@@ -16,11 +16,6 @@ from SublimeLinter.lint import Linter, util
 class AnsibleLint(Linter):
     """Provides an interface to ansible-lint."""
 
-    # ansbile-lint verison requirements check
-    version_args = '--version'
-    version_re = r'(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 3.0.1'
-
     # linter settings
     cmd = ('ansible-lint', '${args}', '${file}')
     regex = r'^.+:(?P<line>\d+): \[.(?P<error>.+)\] (?P<message>.+)'
@@ -44,4 +39,3 @@ class AnsibleLint(Linter):
         '-t': '',
         '-x': '',
     }
-    inline_overrides = ['c', 'exclude', 'r', 'R', 't', 'x']


### PR DESCRIPTION
Various settings were moved from deprecated to obsolete in SublimeLinter v4.12.

These are now removed, and the linter itself cleaned up to not trigger these warnings.