### PR TITLE
Will support Ansible Lint 5

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -47,6 +47,7 @@ class AnsibleLint(Linter):
     }
 
     def __init__(self, view, settings):
+        """If it uses Ansible Lint 5 will be updated the regex."""
         super(AnsibleLint, self).__init__(view, settings)
 
         # Must be resolved the path of Ansible Lint and Ansible if you'd like to use Ansible Lint 5.
@@ -62,7 +63,7 @@ class AnsibleLint(Linter):
             proc = subprocess.Popen(['ansible-lint', '--version'], env=env, stdout=PIPE, stdin=PIPE)
             result = proc.communicate()[0].decode('utf-8')
             ansible_version = re.findall(r'ansible-lint (\d+.\d+.\d+)', result)[0]
-        except:
+        except Exception:
             ansible_version = None
 
         # regex to re-set if Ansible Lint version is 5 or more

--- a/linter.py
+++ b/linter.py
@@ -11,6 +11,11 @@
 """This module exports the AnsibleLint plugin class."""
 
 from SublimeLinter.lint import Linter, util
+from distutils.version import LooseVersion
+import re
+import os
+import subprocess
+from subprocess import PIPE
 
 
 class AnsibleLint(Linter):
@@ -18,7 +23,8 @@ class AnsibleLint(Linter):
 
     # linter settings
     cmd = ('ansible-lint', '${args}', '${file}')
-    regex = r'^.+:(?P<line>\d+): \[.(?P<error>.+)\] (?P<message>.+)'
+    regex = r'(?P<filename>^.+):(?P<line>\d+): \[.(?P<error>.+)\] (?P<message>.+)'
+
     # -p generate non-multi-line, pep8 compatible output
     multiline = False
 
@@ -39,3 +45,27 @@ class AnsibleLint(Linter):
         '-t': '',
         '-x': '',
     }
+
+    def __init__(self, view, settings):
+        super(AnsibleLint, self).__init__(view, settings)
+
+        # Must be resolved the path of Ansible Lint and Ansible if you'd like to use Ansible Lint 5.
+        # Because the ansible will be called from Ansible Lint 5 in parsing playbook codes.
+        # If the path doesn't resolve, an error for Ansible occurs when Ansible Lint execution.
+        env = os.environ.copy()
+        env_setting = self.settings.get('env', {})
+        if env_setting and 'PATH' in env_setting.keys():
+            env['PATH'] = env['PATH'] + ':%s' % env_setting['PATH']
+
+        # version gets of Ansible Lint
+        try:
+            proc = subprocess.Popen(['ansible-lint', '--version'], env=env, stdout=PIPE, stdin=PIPE)
+            result = proc.communicate()[0].decode('utf-8')
+            ansible_version = re.findall(r'ansible-lint (\d+.\d+.\d+)', result)[0]
+        except:
+            ansible_version = None
+
+        # regex to re-set if Ansible Lint version is 5 or more
+        if ansible_version and LooseVersion(ansible_version) >= ('5.0.0'):
+            regex = r'(?P<filename>^.+):(?P<line>\d+): (?P<message>.+)'
+            self.regex = re.compile(regex, self.re_flags)


### PR DESCRIPTION
##### SUMMARY

First, thanks for the useful plugin!  
The plugin didn't support Ansible Lint 5, so I made a patch to fix it.

This PR is the patch to support Ansible Lint 5.  
In Ansible Lint 5, an output format has been changed, so the regex should change when using 5.

Also, `<filename>` will be supported.